### PR TITLE
Fix for routes when serving for gh pages

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8">
+    <title>Single Page Apps for GitHub Pages</title>
+    <script type="text/javascript">
+        // Single Page Apps for GitHub Pages
+        // https://github.com/rafrex/spa-github-pages
+        // Copyright (c) 2016 Rafael Pedicini, licensed under the MIT License
+        // ----------------------------------------------------------------------
+        // This script takes the current url and converts the path and query
+        // string into just a query string, and then redirects the browser
+        // to the new url with only a query string and hash fragment,
+        // e.g. http://www.foo.tld/one/two?a=b&c=d#qwe, becomes
+        // http://www.foo.tld/?p=/one/two&q=a=b~and~c=d#qwe
+        // Note: this 404.html file must be at least 512 bytes for it to work
+        // with Internet Explorer (it is currently > 512 bytes)
+
+        // If you're creating a Project Pages site and NOT using a custom domain,
+        // then set segmentCount to 1 (enterprise users may need to set it to > 1).
+        // This way the code will only replace the route part of the path, and not
+        // the real directory in which the app resides, for example:
+        // https://username.github.io/repo-name/one/two?a=b&c=d#qwe becomes
+        // https://username.github.io/repo-name/?p=/one/two&q=a=b~and~c=d#qwe
+        // Otherwise, leave segmentCount as 0.
+        var segmentCount = 1;
+
+        var l = window.location;
+        l.replace(
+            l.protocol + '//' + l.hostname + (l.port ? ':' + l.port : '') +
+            l.pathname.split('/').slice(0, 1 + segmentCount).join('/') + '/?p=/' +
+            l.pathname.slice(1).split('/').slice(segmentCount).join('/').replace(/&/g, '~and~') +
+            (l.search ? '&q=' + l.search.slice(1).replace(/&/g, '~and~') : '') +
+            l.hash
+        );
+
+    </script>
+</head>
+
+<body>
+</body>
+
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -1,12 +1,46 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>React-Bootstrap CodeSandbox Starter</title>
-  </head>
-  <body>
-    <noscript>You need to enable JavaScript to run this app.</noscript>
-    <div id="root"></div>
-  </body>
+
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>React-Bootstrap CodeSandbox Starter</title>
+  <!-- Start Single Page Apps for GitHub Pages -->
+  <script type="text/javascript">
+    // Single Page Apps for GitHub Pages
+    // https://github.com/rafrex/spa-github-pages
+    // Copyright (c) 2016 Rafael Pedicini, licensed under the MIT License
+    // ----------------------------------------------------------------------
+    // This script checks to see if a redirect is present in the query string
+    // and converts it back into the correct url and adds it to the
+    // browser's history using window.history.replaceState(...),
+    // which won't cause the browser to attempt to load the new url.
+    // When the single page app is loaded further down in this file,
+    // the correct url will be waiting in the browser's history for
+    // the single page app to route accordingly.
+    (function (l) {
+      if (l.search) {
+        var q = {};
+        l.search.slice(1).split('&').forEach(function (v) {
+          var a = v.split('=');
+          q[a[0]] = a.slice(1).join('=').replace(/~and~/g, '&');
+        });
+        if (q.p !== undefined) {
+          window.history.replaceState(null, null,
+            l.pathname.slice(0, -1) + (q.p || '') +
+            (q.q ? ('?' + q.q) : '') +
+            l.hash
+          );
+        }
+      }
+    }(window.location))
+  </script>
+  <!-- End Single Page Apps for GitHub Pages -->
+</head>
+
+<body>
+  <noscript>You need to enable JavaScript to run this app.</noscript>
+  <div id="root"></div>
+</body>
+
 </html>

--- a/src/App.js
+++ b/src/App.js
@@ -10,7 +10,7 @@ import Landing from './Landing';
 import Cases from './Cases';
 
 const App = () => (
-  <Router>
+  <Router basename='/RadiologyCaseTracker'>
     <Switch>
       <Route path='/cases' >
         <Cases />

--- a/src/Landing.js
+++ b/src/Landing.js
@@ -5,6 +5,7 @@ import Row from 'react-bootstrap/Row';
 import Container from 'react-bootstrap/Container';
 import Button from 'react-bootstrap/Button';
 import Form from 'react-bootstrap/Form';
+import { Link } from 'react-router-dom';
 
 
 const Landing = () => (
@@ -16,7 +17,7 @@ const Landing = () => (
         <Button>Save</Button>
       </Col>
       <Col>
-      <a href="cases">Back to List of Cases</a>
+        <Link to="/cases">Back to List of Cases</Link>
       </Col>
     </Row>
     <hr></hr>
@@ -55,7 +56,7 @@ const Landing = () => (
         <Form.Check inline label="3 Days" type="checkbox" id={`inline-checkbox-1`} />
         <Form.Check inline label="7 Days" type="checkbox" id={`inline-checkbox-2`} />
         <Form.Check inline label="14 Days" type="checkbox" id={`inline-checkbox-3`} />
-        <Form.Check inline label="1 Month" type="checkbox" id={`inline-checkbox-4`} checked/>
+        <Form.Check inline label="1 Month" type="checkbox" id={`inline-checkbox-4`} checked />
         <Form.Check inline label="6 Months" type="checkbox" id={`inline-checkbox-5`} />
         <Form.Check inline label="1 Year" type="checkbox" id={`inline-checkbox-6`} />
         <Form.Check inline label="Custom Date" type="checkbox" id={'inline-checkbox-7'} />


### PR DESCRIPTION
- Add 404 hack from https://github.com/rafrex/spa-github-pages
- Add `basepath` to Router config
- Use <Link> instead of <a> for internal links